### PR TITLE
Centralize bot base-dir configuration and remove fixed paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,18 +10,18 @@ Dieses Verzeichnis enthält die Bots, die ÖPNV-Meldungen von Twitter/X (per Sel
 
 ## Komponenten
 - `twitter_bot.py`: Selenium-Scraper für eine X-Liste. Nutzt ein lokales Firefox-Profil, dedupliziert über die gemeinsame SQLite-DB `nitter_bot.db` und sendet neue Tweets an Telegram und Mastodon.
-- `nitter_bot.py`: Pollt die lokale Nitter-Instanz (`http://localhost:8080/<user>/rss`) statt Selenium/X. History und Nutzer-Intervalle liegen in `nitter_bot.db` und sollen den Twitter-Bot langfristig ersetzen.
+- `nitter_bot.py`: Pollt die lokale Nitter-Instanz (`http://localhost:8081/<user>/rss`) statt Selenium/X. History und Nutzer-Intervalle liegen in `nitter_bot.db` und sollen den Twitter-Bot langfristig ersetzen.
 - `bsky_feed_monitor.py`: Pollt konfigurierte Bluesky-RSS-Feeds (z. B. VIZ Berlin) und leitet neue Einträge an Telegram/Mastodon weiter.
 - `telegram_bot.py`: Versendet Tweets/Feeds an alle in der DB hinterlegten Chats. Filterwörter pro Chat bestimmen, was zugestellt wird.
 - `telegram_control_bot.py`: Telegram-Bot zur Verwaltung von Chat-IDs und Filtern (`/start`, `/status`, `/addfilterrules`, `/deletefilterrules`, `/deleteallrules`, `/list`, `/about`, `/datenschutz`). Admin-Kommandos erlauben Service-Meldungen an alle Kanäle und Log-Auszüge.
 - `mastodon_bot.py`: Postet Tweets/Feeds auf `berlin.social`, `toot.berlin` und `mastodon.berlin` (Tokens aus ENV). Unterstützt Bilder/Videos, generiert Alt-Texte via Gemini und taggt Nutzer basierend auf DB-Regeln.
 - `mastodon_control_bot.py`: Mastodon-DM-Bot zum Verwalten der Tagging-Regeln (`/start`, `/add`, `/list`, `/overview`, `/delete`, `/pause`, `/resume`, `/schedule`, `/stop`). Lauscht optional auf Events vom Posting-Bot.
 - `gemini_helper.py` + `test_alt_text.py`: Modellverwaltung für Gemini (Cache in der DB) und Offline/Online-Test der Alt-Text-Generierung (`python test_alt_text.py --image <pfad> [--dummy]`).
-- Daten/Logs: zentrale SQLite-DB `nitter_bot.db` (Chat-Filter, Mastodon-Regeln, Gemini-Cache, Histories inkl. Mastodon-Posts) und Log unter `/home/sascha/bots/twitter_bot.log`.
+- Daten/Logs: zentrale SQLite-DB `nitter_bot.db` (Chat-Filter, Mastodon-Regeln, Gemini-Cache, Histories inkl. Mastodon-Posts) und Log unter `$BOTS_BASE_DIR/twitter_bot.log` (Default: aktueller Repo-Ordner).
 
 ## Voraussetzungen & Installation
 - Python 3 + virtuelles Environment (empfohlen):  
-  `python3 -m venv /home/sascha/bots/venv && source /home/sascha/bots/venv/bin/activate`
+  `export BOTS_BASE_DIR="$(pwd)" && python3 -m venv "$BOTS_BASE_DIR/venv" && source "$BOTS_BASE_DIR/venv/bin/activate"`
 - Abhängigkeiten installieren (im Ordner `bots/`):  
   `pip install -r requirements.txt`
 - Firefox + Geckodriver (in `twitter_bot.py` aktuell `/usr/local/bin/geckodriver`). Nutze ein eingeloggtes Firefox-Profil für X (`firefox_profile_path`).
@@ -31,8 +31,8 @@ Dieses Verzeichnis enthält die Bots, die ÖPNV-Meldungen von Twitter/X (per Sel
   - Gemini: `GEMINI_API_KEY` (optional zusätzlich: `GEMINI_API_KEY1` bis `GEMINI_API_KEY4` für Round-Robin)
   - Optional: `MASTODON_CONTROL_EVENT_ENABLED|HOST|PORT`, `MASTODON_CONTROL_POLL_INTERVAL`
 
-> Hinweis: Alle Skripte verwenden absolute Pfade auf `/home/sascha/bots/…`. Wenn das Repo anders liegt, passe die Konstanten (`firefox_profile_path`, `geckodriver_path`, `filename`, `DATA_FILE`, `RULES_FILE`, Log-Pfade) in den Skripten an.
-  Die SQLite-DB kann über `NITTER_DB_PATH` umgezogen werden (Standard `/home/sascha/bots/nitter_bot.db`).
+> Hinweis: Laufzeitpfade werden zentral über `BOTS_BASE_DIR` gesteuert (Default: Repo-Ordner).  
+  Die SQLite-DB kann über `NITTER_DB_PATH` umgezogen werden (Standard `$BOTS_BASE_DIR/nitter_bot.db`).
 
 ## Konfiguration
 - **Twitter/X-Scraper (`twitter_bot.py`)**
@@ -43,7 +43,7 @@ Dieses Verzeichnis enthält die Bots, die ÖPNV-Meldungen von Twitter/X (per Sel
   - Optional ohne Login: Profil-Zuweisung in `twitter_bot.py` auskommentieren und `delete_temp_files` deaktivieren (siehe Hinweise oben).
 
 - **Nitter-RSS (`nitter_bot.py`)**
-  - Arbeitet gegen `NITTER_BASE_URL` (Standard `http://localhost:8080`) und liest Accounts samt Intervallen/Zeitfenstern aus der DB (Default-Seed wie bisher).
+  - Arbeitet gegen `NITTER_BASE_URL` (Standard `http://localhost:8081`) und liest Accounts samt Intervallen/Zeitfenstern aus der DB (Default-Seed wie bisher).
   - Default-Poll: 15 Minuten (900 s); `SBahnBerlin` ist per Seed mit 120 s von 05:55–22:05 hinterlegt.
   - Dedupliziert per DB-History und baut die Status-Links zu `x.com/<user>/status/<id>` für Telegram/Mastodon.
   - History-Limit per `NITTER_HISTORY_LIMIT` einstellbar; `NITTER_POLL_INTERVAL` steuert das Loop-Fallback-Sleep (min. 15 s).
@@ -65,7 +65,7 @@ Dieses Verzeichnis enthält die Bots, die ÖPNV-Meldungen von Twitter/X (per Sel
 
 ## Starten
 1) Virtuelle Umgebung aktivieren:  
-   `source /home/sascha/bots/venv/bin/activate`
+   `export BOTS_BASE_DIR="$(pwd)" && source "$BOTS_BASE_DIR/venv/bin/activate"`
 
 2) Bots starten (je nach Bedarf separate Prozesse/Services):
    - X-Scraper: `python twitter_bot.py`
@@ -95,6 +95,7 @@ Dieses Verzeichnis enthält die Bots, die ÖPNV-Meldungen von Twitter/X (per Sel
 - Env-File anlegen (für Service und lokale Tests):  
   ```bash
   sudo tee /etc/twitter_bot.env >/dev/null <<'EOF'
+  BOTS_BASE_DIR=/home/<user>/Dokumente/bots
   GEMINI_API_KEY=DEIN_KEY
   GEMINI_API_KEY1=OPTIONAL_KEY_1
   GEMINI_API_KEY2=OPTIONAL_KEY_2
@@ -108,7 +109,7 @@ Dieses Verzeichnis enthält die Bots, die ÖPNV-Meldungen von Twitter/X (per Sel
   EOF
   ```
 - Manuell testen ohne Service:  
-  `set -a; source /etc/twitter_bot.env; set +a; cd /home/sascha/bots; python twitter_bot.py`  
+  `set -a; source /etc/twitter_bot.env; set +a; export BOTS_BASE_DIR="$(pwd)"; python twitter_bot.py`  
   (analog für `bsky_feed_monitor.py`, `telegram_control_bot.py`, `mastodon_control_bot.py`).
 - Installation (Beispiel `twitter_bot`):
   ```bash
@@ -119,9 +120,9 @@ Dieses Verzeichnis enthält die Bots, die ÖPNV-Meldungen von Twitter/X (per Sel
   Weitere Bots analog mit den jeweiligen Dateien aus `services/`.
 
 ## Logging, Daten & Betrieb
-- Zentrales Log: `/home/sascha/bots/twitter_bot.log` (alle Module). Admin-Befehle in Telegram zeigen Auszüge.
+- Zentrales Log: `$BOTS_BASE_DIR/twitter_bot.log` (alle Module). Admin-Befehle in Telegram zeigen Auszüge.
 - Historien/Caches landen gesammelt in `nitter_bot.db` (Buckets u. a. für Twitter/Nitter-History, Bluesky-Feeds, Telegram-Filter, Mastodon-Regeln/-Posts, Gemini-Status).
-- Für Dauerbetrieb können systemd-Services genutzt werden (ExecStart z. B. `/home/sascha/bots/venv/bin/python /home/sascha/bots/twitter_bot.py`; ENV-Variablen im Service setzen).
+- Für Dauerbetrieb können systemd-Services genutzt werden (ExecStart läuft über `$BOTS_BASE_DIR`; `BOTS_BASE_DIR` wird im `EnvironmentFile` gesetzt).
 
 ## Danksagung
 Dank an [shaikhsajid1111](https://github.com/shaikhsajid1111/twitter-scraper-selenium/blob/main/twitter_scraper_selenium/element_finder.py) für die CSS-Selector-Basis zum Extrahieren von Tweets.

--- a/bsky_feed_monitor.py
+++ b/bsky_feed_monitor.py
@@ -17,6 +17,7 @@ import pytz
 import telegram_bot
 import mastodon_bot
 import state_store
+from paths import LOG_FILE
 
 # -------------------------
 # Logging configuration
@@ -24,7 +25,7 @@ import state_store
 # Ursprünglich war level=logging.ERROR; fürs Debug/Info beim Start setze ich INFO.
 # Wenn du nur Fehler möchtest, ändere auf logging.ERROR.
 logging.basicConfig(
-    filename='/home/sascha/bots/twitter_bot.log',
+    filename=LOG_FILE,
     level=logging.INFO,
     format='%(asctime)s %(levelname)s %(message)s'
 )

--- a/mastodon_bot.py
+++ b/mastodon_bot.py
@@ -23,6 +23,7 @@ from gemini_helper import GeminiModelManager
 from mastodon_text_utils import split_mastodon_text, sanitize_for_mastodon
 import mastodon_post_store
 import state_store
+from paths import LOG_FILE
 
 GEMINI_KEY_ENV_VARS = [
     "GEMINI_API_KEY",
@@ -84,7 +85,7 @@ client = get_primary_gemini_client()
 gemini_manager = GeminiModelManager(client)
 
 # Configure logging
-LOG_PATH = '/home/sascha/bots/twitter_bot.log'
+LOG_PATH = LOG_FILE
 ALT_TEXT_LOG_PREFIX = "Alt-Text Generierung"
 GEMINI_HELPER_PREFIX = "gemini_helper"
 ALT_TEXT_FALLBACK = "Alt-Text konnte nicht automatisch generiert werden."

--- a/mastodon_control_bot.py
+++ b/mastodon_control_bot.py
@@ -12,6 +12,7 @@ from zoneinfo import ZoneInfo
 from mastodon import Mastodon
 from mastodon_text_utils import split_mastodon_text
 import state_store
+from paths import BASE_DIR, LOG_FILE
 
 # ----------------------------
 # Konstanten / Pfade
@@ -27,7 +28,7 @@ INSTANCES = {
 }
 
 # Logfile (nur zentrales Log)
-BOT_LOG_FILE = "/home/sascha/bots/twitter_bot.log"
+BOT_LOG_FILE = LOG_FILE
 
 # Bots für Fehlerzählung (letzte 24h) im /status
 ALT_TEXT_CATEGORY = "Alt-Text Generierung"
@@ -1014,15 +1015,15 @@ def build_status_text() -> str:
     try:
         twitter_state, _ = get_service_state(
             "twitter_bot.service",
-            fallback_patterns=["twitter_bot", "twitter_bot.py", "/home/sascha/bots/twitter"]
+            fallback_patterns=["twitter_bot", "twitter_bot.py", str(BASE_DIR / "twitter")]
         )
         bsky_state, _ = get_service_state(
             "bsky_bot.service",
-            fallback_patterns=["bsky_bot", "bsky_bot.py", "/home/sascha/bots/bsky", "bluesky"]
+            fallback_patterns=["bsky_bot", "bsky_bot.py", str(BASE_DIR / "bsky"), "bluesky"]
         )
         nitter_state, _ = get_service_state(
             "nitter_bot.service",
-            fallback_patterns=["nitter_bot", "nitter_bot.py", "/home/sascha/Dokumente/bots/nitter"]
+            fallback_patterns=["nitter_bot", "nitter_bot.py", str(BASE_DIR / "nitter")]
         )
 
         twitter_running = twitter_state.startswith("läuft")

--- a/nitter_bot.py
+++ b/nitter_bot.py
@@ -19,8 +19,9 @@ import requests
 import telegram_bot
 import mastodon_bot
 import state_store
+from paths import BASE_DIR as DEFAULT_BASE_DIR
 
-BASE_DIR = os.environ.get("BOTS_BASE_DIR", "/home/sascha/bots")
+BASE_DIR = os.environ.get("BOTS_BASE_DIR", str(DEFAULT_BASE_DIR))
 LOG_PATH = os.path.join(BASE_DIR, "twitter_bot.log")
 POLL_INTERVAL = int(os.environ.get("NITTER_POLL_INTERVAL", "60"))
 HISTORY_LIMIT = int(os.environ.get("NITTER_HISTORY_LIMIT", "200"))

--- a/paths.py
+++ b/paths.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+BASE_DIR = Path(os.environ.get("BOTS_BASE_DIR") or Path(__file__).resolve().parent).resolve()
+LOG_FILE = str(BASE_DIR / "twitter_bot.log")
+LOG_DIR = str(BASE_DIR / "logs")
+DATA_FILE = str(BASE_DIR / "data.json")
+DEFAULT_DB_PATH = str(BASE_DIR / "nitter_bot.db")

--- a/rotate_twitter_log.sh
+++ b/rotate_twitter_log.sh
@@ -1,17 +1,20 @@
 #!/bin/bash
 set -e
 
-BASE_DIR="/home/sascha/bots"
+BASE_DIR="${BOTS_BASE_DIR:-$(cd "$(dirname "$0")" && pwd)}"
 LOGFILE="$BASE_DIR/twitter_bot.log"
 LOGDIR="$BASE_DIR/logs"
+PYTHON_BIN="$BASE_DIR/venv/bin/python3"
 
 YESTERDAY=$(date -d "yesterday" +"%Y-%m-%d")
 ARCHIVED_LOG="$LOGDIR/twitter_bot.log.$YESTERDAY"
 
 cd -- "$BASE_DIR"
-source venv/bin/activate
-
-python store_twitter_logs.py
+if [ -x "$PYTHON_BIN" ]; then
+    "$PYTHON_BIN" store_twitter_logs.py
+else
+    python3 store_twitter_logs.py
+fi
 
 mkdir -p "$LOGDIR"
 
@@ -23,5 +26,3 @@ touch "$LOGFILE"
 chmod 644 "$LOGFILE"
 
 find "$LOGDIR" -type f -name "twitter_bot.log.*" -mtime +14 -delete
-
-deactivate

--- a/services/bsky_bot.service
+++ b/services/bsky_bot.service
@@ -4,8 +4,8 @@ After=network.target
 
 [Service]
 EnvironmentFile=/etc/twitter_bot.env
-WorkingDirectory=/home/sascha/bots
-ExecStart=/home/sascha/bots/venv/bin/python3 /home/sascha/bots/bsky_feed_monitor.py
+WorkingDirectory=%h
+ExecStart=/bin/bash -lc '"${BOTS_BASE_DIR:?missing BOTS_BASE_DIR}/venv/bin/python3" "${BOTS_BASE_DIR:?missing BOTS_BASE_DIR}/bsky_feed_monitor.py"'
 Restart=always
 RestartSec=10
 User=sascha

--- a/services/mastodon_control_bot.service
+++ b/services/mastodon_control_bot.service
@@ -4,8 +4,8 @@ After=network.target
 
 [Service]
 EnvironmentFile=/etc/twitter_bot.env
-WorkingDirectory=/home/sascha/bots
-ExecStart=/home/sascha/bots/venv/bin/python3 /home/sascha/bots/mastodon_control_bot.py
+WorkingDirectory=%h
+ExecStart=/bin/bash -lc '"${BOTS_BASE_DIR:?missing BOTS_BASE_DIR}/venv/bin/python3" "${BOTS_BASE_DIR:?missing BOTS_BASE_DIR}/mastodon_control_bot.py"'
 Restart=always
 RestartSec=10
 User=sascha

--- a/services/nitter_bot.service
+++ b/services/nitter_bot.service
@@ -4,8 +4,8 @@ After=network.target
 
 [Service]
 EnvironmentFile=/etc/twitter_bot.env
-WorkingDirectory=/home/sascha/bots
-ExecStart=/home/sascha/bots/venv/bin/python3 /home/sascha/bots/nitter_bot.py
+WorkingDirectory=%h
+ExecStart=/bin/bash -lc '"${BOTS_BASE_DIR:?missing BOTS_BASE_DIR}/venv/bin/python3" "${BOTS_BASE_DIR:?missing BOTS_BASE_DIR}/nitter_bot.py"'
 Restart=always
 RestartSec=10
 User=sascha

--- a/services/telegram_control_bot.service
+++ b/services/telegram_control_bot.service
@@ -4,8 +4,8 @@ After=network.target
 
 [Service]
 EnvironmentFile=/etc/twitter_bot.env
-WorkingDirectory=/home/sascha/bots
-ExecStart=/home/sascha/bots/venv/bin/python3 /home/sascha/bots/telegram_control_bot.py
+WorkingDirectory=%h
+ExecStart=/bin/bash -lc '"${BOTS_BASE_DIR:?missing BOTS_BASE_DIR}/venv/bin/python3" "${BOTS_BASE_DIR:?missing BOTS_BASE_DIR}/telegram_control_bot.py"'
 Restart=always
 RestartSec=10
 User=sascha

--- a/services/twitter_bot.service
+++ b/services/twitter_bot.service
@@ -4,8 +4,8 @@ After=network.target
 
 [Service]
 EnvironmentFile=/etc/twitter_bot.env
-WorkingDirectory=/home/sascha/bots
-ExecStart=/home/sascha/bots/venv/bin/python3 /home/sascha/bots/twitter_bot.py
+WorkingDirectory=%h
+ExecStart=/bin/bash -lc '"${BOTS_BASE_DIR:?missing BOTS_BASE_DIR}/venv/bin/python3" "${BOTS_BASE_DIR:?missing BOTS_BASE_DIR}/twitter_bot.py"'
 Restart=always
 RestartSec=10
 User=sascha

--- a/storage.py
+++ b/storage.py
@@ -4,11 +4,12 @@ import os
 import sqlite3
 import time
 from typing import Any, Dict, Iterable, Tuple
+from paths import DEFAULT_DB_PATH
 
 DB_PATH = (
     os.environ.get("NITTER_DB_PATH")
     or os.environ.get("MASTODON_POST_DB")
-    or "/home/sascha/bots/nitter_bot.db"
+    or DEFAULT_DB_PATH
 )
 
 _initialized = False

--- a/store_twitter_logs.py
+++ b/store_twitter_logs.py
@@ -3,8 +3,9 @@ import time
 from pathlib import Path
 
 from state_store import store_archive_logs
+from paths import LOG_FILE
 
-LOGFILE = Path("/home/sascha/bots/twitter_bot.log")
+LOGFILE = Path(LOG_FILE)
 
 def main():
     if not LOGFILE.exists():

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -6,13 +6,14 @@ import logging
 import re
 import time
 import state_store
+from paths import DATA_FILE as DEFAULT_DATA_FILE, LOG_FILE
 
 # DATA_FILE = 'data.json'
-DATA_FILE = '/home/sascha/bots/data.json'
+DATA_FILE = DEFAULT_DATA_FILE
 
 # Configure logging
 logging.basicConfig(
-    filename='/home/sascha/bots/twitter_bot.log',
+    filename=LOG_FILE,
     level=logging.INFO,
     format='%(asctime)s %(levelname)s:%(message)s'
 )

--- a/telegram_control_bot.py
+++ b/telegram_control_bot.py
@@ -9,6 +9,7 @@ import logging
 import subprocess
 import re
 from mastodon_text_utils import split_mastodon_text
+from paths import BASE_DIR, DATA_FILE as DEFAULT_DATA_FILE, LOG_DIR as DEFAULT_LOG_DIR, LOG_FILE
 
 # Secrets aus ENV (global + local):
 #   telegram_token  -> Bot Token
@@ -16,7 +17,7 @@ from mastodon_text_utils import split_mastodon_text
 BOT_TOKEN = os.environ.get("telegram_token")
 admin_env = os.environ.get("telegram_admin")
 
-LOG_DIR = '/home/sascha/bots/logs'
+LOG_DIR = DEFAULT_LOG_DIR
 MAX_ARCHIVES = 3
 TELEGRAM_CONTROL_TIMEOUT_PAUSE_SECONDS = 10 * 60
 BOT_LOG_FORMAT = '%(asctime)s %(levelname)s:%(message)s'
@@ -29,16 +30,16 @@ except Exception:
 
 # Configure logging (für dieses Script)
 logging.basicConfig(
-    filename='/home/sascha/bots/twitter_bot.log',
+    filename=LOG_FILE,
     level=logging.WARNING,
     format=BOT_LOG_FORMAT
 )
 
 # Dateiname für Chat-IDs und Filterregeln
-DATA_FILE = '/home/sascha/bots/data.json'
+DATA_FILE = DEFAULT_DATA_FILE
 
 # Zentrales Bot-Logfile (alle Module schreiben hier rein)
-BOT_LOG_FILE = '/home/sascha/bots/twitter_bot.log'
+BOT_LOG_FILE = LOG_FILE
 
 # Bots für Fehlerzählung (letzte 24h) im /status
 ALT_TEXT_CATEGORY = "Alt-Text Generierung"
@@ -794,15 +795,15 @@ async def status_command(bot, chat_id: int, admin_view: bool = False):
     try:
         twitter_state, _ = get_service_state(
             "twitter_bot.service",
-            fallback_patterns=["twitter_bot", "twitter_bot.py", "/home/sascha/bots/twitter"]
+            fallback_patterns=["twitter_bot", "twitter_bot.py", str(BASE_DIR / "twitter")]
         )
         bsky_state, _ = get_service_state(
             "bsky_bot.service",
-            fallback_patterns=["bsky_bot", "bsky_bot.py", "/home/sascha/bots/bsky", "bluesky"]
+            fallback_patterns=["bsky_bot", "bsky_bot.py", str(BASE_DIR / "bsky"), "bluesky"]
         )
         nitter_state, _ = get_service_state(
             "nitter_bot.service",
-            fallback_patterns=["nitter_bot", "nitter_bot.py", "/home/sascha/Dokumente/bots/nitter"]
+            fallback_patterns=["nitter_bot", "nitter_bot.py", str(BASE_DIR / "nitter")]
         )
 
         twitter_running = twitter_state.startswith("läuft")

--- a/twitter_bot.py
+++ b/twitter_bot.py
@@ -21,6 +21,7 @@ from dateutil.parser import parse
 import pytz
 import requests  # Neuer Import für URL-Erweiterung
 import state_store
+from paths import LOG_FILE
 
 #print("Imports successful")
 
@@ -38,7 +39,7 @@ HISTORY_LIMIT = 100
 HISTORY_TRIM_TO = 50
 
 # Logging configuration
-logging.basicConfig(filename='/home/sascha/bots/twitter_bot.log', level=logging.WARNING, force=True)
+logging.basicConfig(filename=LOG_FILE, level=logging.WARNING, force=True)
 #print("Logging configured")
 
 # Set Firefox options


### PR DESCRIPTION
## Summary
- add central path module `paths.py` using `BOTS_BASE_DIR` (default: current repo directory)
- switch bot/runtime modules to shared path constants for log/data/db defaults
- remove hardcoded `/home/sascha/bots` references from scripts and Python defaults
- update systemd service templates to execute via `BOTS_BASE_DIR` from `EnvironmentFile`
- update `rotate_twitter_log.sh` and README to follow the same base-dir model

## Checks
- `./venv/bin/python -m compileall -q -x '(^|/)venv($|/)' .`

Fixes #3
