### PR TITLE
Fix log rotation handler behavior across bots

### DIFF
--- a/bsky_feed_monitor.py
+++ b/bsky_feed_monitor.py
@@ -4,6 +4,7 @@
 import time
 import argparse
 import logging
+from logging.handlers import WatchedFileHandler
 import asyncio
 import hashlib
 import re
@@ -24,7 +25,7 @@ import state_store
 # Ursprünglich war level=logging.ERROR; fürs Debug/Info beim Start setze ich INFO.
 # Wenn du nur Fehler möchtest, ändere auf logging.ERROR.
 logging.basicConfig(
-    filename='/home/sascha/bots/twitter_bot.log',
+    handlers=[WatchedFileHandler('/home/sascha/bots/twitter_bot.log')],
     level=logging.INFO,
     format='%(asctime)s %(levelname)s %(message)s'
 )

--- a/mastodon_bot.py
+++ b/mastodon_bot.py
@@ -2,6 +2,7 @@ import asyncio
 import os
 import re
 import logging
+from logging.handlers import WatchedFileHandler
 from threading import Lock
 from datetime import date, datetime, time, timedelta
 from urllib.parse import urlparse
@@ -97,7 +98,7 @@ INSTANCE_QUOTE_POLICIES: dict[str, str] = {}
 QUOTE_POLICY_DISABLED_VALUES = {"disabled", "deny", "disallow"}
 
 logging.basicConfig(
-    filename=LOG_PATH,
+    handlers=[WatchedFileHandler(LOG_PATH)],
     level=logging.INFO,
     format='%(asctime)s %(levelname)s:%(message)s',
     force=True,
@@ -114,7 +115,7 @@ helper_logger.propagate = True
 # Eigener Alt-Text-Logger mit INFO-Level, ohne globale Log-Flut.
 alt_text_logger = logging.getLogger("mastodon_alt_text")
 if not alt_text_logger.handlers:
-    _alt_handler = logging.FileHandler(LOG_PATH)
+    _alt_handler = WatchedFileHandler(LOG_PATH)
     _alt_handler.setLevel(logging.INFO)
     _alt_handler.setFormatter(logging.Formatter('%(asctime)s %(levelname)s:%(message)s'))
     alt_text_logger.addHandler(_alt_handler)

--- a/mastodon_control_bot.py
+++ b/mastodon_control_bot.py
@@ -2,6 +2,7 @@ import asyncio
 import html
 import json
 import logging
+from logging.handlers import WatchedFileHandler
 import os
 import re
 import subprocess
@@ -132,7 +133,7 @@ def setup_logging():
         logger.handlers.clear()
 
     try:
-        handler = logging.FileHandler(BOT_LOG_FILE)
+        handler = WatchedFileHandler(BOT_LOG_FILE)
         handler.setLevel(logging.WARNING)
         handler.setFormatter(fmt)
         logger.addHandler(handler)
@@ -157,7 +158,7 @@ def _build_file_logger(name: str, *, level: int) -> logging.Logger:
             return logger
 
     try:
-        handler = logging.FileHandler(BOT_LOG_FILE)
+        handler = WatchedFileHandler(BOT_LOG_FILE)
     except Exception:
         return logger
 

--- a/nitter_bot.py
+++ b/nitter_bot.py
@@ -5,6 +5,7 @@ import asyncio
 import html
 import json
 import logging
+from logging.handlers import WatchedFileHandler
 import os
 import re
 import time
@@ -77,7 +78,7 @@ TEXT_URL_RX = re.compile(
 MENTION_RE = re.compile(r"(?<!\w)@([A-Za-z0-9_]{1,30})")
 
 logging.basicConfig(
-    filename=LOG_PATH,
+    handlers=[WatchedFileHandler(LOG_PATH)],
     level=logging.INFO,
     format="%(asctime)s %(levelname)s %(message)s",
 )

--- a/rotate_twitter_log.sh
+++ b/rotate_twitter_log.sh
@@ -1,27 +1,28 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
-BASE_DIR="/home/sascha/bots"
-LOGFILE="$BASE_DIR/twitter_bot.log"
-LOGDIR="$BASE_DIR/logs"
+BASE_DIR="${BOTS_BASE_DIR:-/home/sascha/bots}"
+LOGFILE="${BOT_LOG_FILE:-$BASE_DIR/twitter_bot.log}"
+LOGDIR="${TWITTER_LOG_ARCHIVE_DIR:-$BASE_DIR/logs}"
+PYTHON_BIN="${PYTHON_BIN:-$BASE_DIR/venv/bin/python3}"
 
 YESTERDAY=$(date -d "yesterday" +"%Y-%m-%d")
 ARCHIVED_LOG="$LOGDIR/twitter_bot.log.$YESTERDAY"
 
 cd -- "$BASE_DIR"
-source venv/bin/activate
-
-python store_twitter_logs.py
+if [ -x "$PYTHON_BIN" ]; then
+    "$PYTHON_BIN" store_twitter_logs.py
+else
+    python3 store_twitter_logs.py
+fi
 
 mkdir -p "$LOGDIR"
+mkdir -p "$(dirname "$LOGFILE")"
 
 if [ -f "$LOGFILE" ]; then
     mv "$LOGFILE" "$ARCHIVED_LOG"
 fi
 
-touch "$LOGFILE"
-chmod 644 "$LOGFILE"
+install -m 644 /dev/null "$LOGFILE"
 
 find "$LOGDIR" -type f -name "twitter_bot.log.*" -mtime +14 -delete
-
-deactivate

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -3,6 +3,7 @@ import os
 import telegram
 import json
 import logging
+from logging.handlers import WatchedFileHandler
 import re
 import time
 import state_store
@@ -12,7 +13,7 @@ DATA_FILE = '/home/sascha/bots/data.json'
 
 # Configure logging
 logging.basicConfig(
-    filename='/home/sascha/bots/twitter_bot.log',
+    handlers=[WatchedFileHandler('/home/sascha/bots/twitter_bot.log')],
     level=logging.INFO,
     format='%(asctime)s %(levelname)s:%(message)s'
 )

--- a/telegram_control_bot.py
+++ b/telegram_control_bot.py
@@ -6,6 +6,7 @@ import json
 import telegram
 from datetime import datetime, timedelta
 import logging
+from logging.handlers import WatchedFileHandler
 import subprocess
 import re
 from mastodon_text_utils import split_mastodon_text
@@ -29,7 +30,7 @@ except Exception:
 
 # Configure logging (für dieses Script)
 logging.basicConfig(
-    filename='/home/sascha/bots/twitter_bot.log',
+    handlers=[WatchedFileHandler('/home/sascha/bots/twitter_bot.log')],
     level=logging.WARNING,
     format=BOT_LOG_FORMAT
 )
@@ -170,7 +171,7 @@ def _build_file_logger(name: str, *, level: int) -> logging.Logger:
             return logger
 
     try:
-        handler = logging.FileHandler(BOT_LOG_FILE)
+        handler = WatchedFileHandler(BOT_LOG_FILE)
     except Exception:
         return logger
 

--- a/twitter_bot.py
+++ b/twitter_bot.py
@@ -7,6 +7,7 @@ import re
 import shutil
 import asyncio
 import logging
+from logging.handlers import WatchedFileHandler
 from typing import Optional, Tuple
 from urllib.parse import urlparse
 from selenium import webdriver
@@ -38,7 +39,11 @@ HISTORY_LIMIT = 100
 HISTORY_TRIM_TO = 50
 
 # Logging configuration
-logging.basicConfig(filename='/home/sascha/bots/twitter_bot.log', level=logging.WARNING, force=True)
+logging.basicConfig(
+    handlers=[WatchedFileHandler('/home/sascha/bots/twitter_bot.log')],
+    level=logging.WARNING,
+    force=True
+)
 #print("Logging configured")
 
 # Set Firefox options


### PR DESCRIPTION
## Summary
- switch all bot file loggers from `FileHandler` to `WatchedFileHandler`
- keep log formatting/levels unchanged while ensuring log writers reopen after external rotation
- harden `rotate_twitter_log.sh` with strict shell mode and safer logfile recreation

## Checks
- `python3 -m compileall .` (fails in vendored `venv` site-packages with legacy asyncio syntax)
- `python3 -m compileall -q -x '(^|/)venv($|/)' .`
- `bash -n rotate_twitter_log.sh`

Fixes #4