### PR TITLE
Harden numeric ENV parsing for bot startup

### DIFF
--- a/mastodon_control_bot.py
+++ b/mastodon_control_bot.py
@@ -16,8 +16,41 @@ import state_store
 # ----------------------------
 # Konstanten / Pfade
 # ----------------------------
-# Serverseitiges Rate-Limit vermeiden: Minimum 5s, Default 90s (Empfehlung)
-POLL_INTERVAL_SEC = max(5, int(os.environ.get("MASTODON_CONTROL_POLL_INTERVAL", "180")))
+_ENV_PARSE_WARNINGS: list[str] = []
+
+
+def _parse_int_env(
+    name: str,
+    default: int,
+    *,
+    min_value: int | None = None,
+    max_value: int | None = None,
+) -> int:
+    raw = os.environ.get(name)
+    if raw is None or not str(raw).strip():
+        return default
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        _ENV_PARSE_WARNINGS.append(
+            f"mastodon_control_bot: Ungueltiger ENV-Wert '{name}={raw}', verwende Default {default}."
+        )
+        return default
+    if min_value is not None and value < min_value:
+        _ENV_PARSE_WARNINGS.append(
+            f"mastodon_control_bot: ENV '{name}' unter Minimum {min_value} ({value}), verwende {min_value}."
+        )
+        return min_value
+    if max_value is not None and value > max_value:
+        _ENV_PARSE_WARNINGS.append(
+            f"mastodon_control_bot: ENV '{name}' ueber Maximum {max_value} ({value}), verwende {max_value}."
+        )
+        return max_value
+    return value
+
+
+# Serverseitiges Rate-Limit vermeiden: Minimum 5s, Default 180s
+POLL_INTERVAL_SEC = _parse_int_env("MASTODON_CONTROL_POLL_INTERVAL", 180, min_value=5)
 
 # Gleiche Instanzen wie mastodon_bot
 INSTANCES = {
@@ -62,7 +95,7 @@ BERLIN_TZ = ZoneInfo("Europe/Berlin")
 
 # Event-Bridge vom mastodon_bot
 EVENT_HOST = os.environ.get("MASTODON_CONTROL_EVENT_HOST", "127.0.0.1")
-EVENT_PORT = int(os.environ.get("MASTODON_CONTROL_EVENT_PORT", "8123"))
+EVENT_PORT = _parse_int_env("MASTODON_CONTROL_EVENT_PORT", 8123, min_value=1, max_value=65535)
 EVENT_ENABLED = os.environ.get("MASTODON_CONTROL_EVENT_ENABLED", "1").lower() not in {"0", "false", "no"}
 BOT_LOG_FORMAT = "%(asctime)s %(levelname)s:%(message)s"
 
@@ -139,6 +172,8 @@ def setup_logging():
     except Exception:
         # Falls das zentrale Log nicht schreibbar ist, nicht crashen
         pass
+    for warning in _ENV_PARSE_WARNINGS:
+        logging.warning(warning)
 
 
 setup_logging()

--- a/nitter_bot.py
+++ b/nitter_bot.py
@@ -22,11 +22,31 @@ import state_store
 
 BASE_DIR = os.environ.get("BOTS_BASE_DIR", "/home/sascha/bots")
 LOG_PATH = os.path.join(BASE_DIR, "twitter_bot.log")
-POLL_INTERVAL = int(os.environ.get("NITTER_POLL_INTERVAL", "60"))
-HISTORY_LIMIT = int(os.environ.get("NITTER_HISTORY_LIMIT", "200"))
-MAX_ITEM_AGE_SECONDS = max(
-    0, int(os.environ.get("NITTER_MAX_ITEM_AGE_SECONDS", str(2 * 60 * 60)))
-)
+_ENV_PARSE_WARNINGS: list[str] = []
+
+
+def _parse_int_env(name: str, default: int, *, min_value: int | None = None) -> int:
+    raw = os.environ.get(name)
+    if raw is None or not str(raw).strip():
+        return default
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        _ENV_PARSE_WARNINGS.append(
+            f"nitter_bot: Ungueltiger ENV-Wert '{name}={raw}', verwende Default {default}."
+        )
+        return default
+    if min_value is not None and value < min_value:
+        _ENV_PARSE_WARNINGS.append(
+            f"nitter_bot: ENV '{name}' unter Minimum {min_value} ({value}), verwende {min_value}."
+        )
+        return min_value
+    return value
+
+
+POLL_INTERVAL = _parse_int_env("NITTER_POLL_INTERVAL", 60, min_value=1)
+HISTORY_LIMIT = _parse_int_env("NITTER_HISTORY_LIMIT", 200, min_value=1)
+MAX_ITEM_AGE_SECONDS = _parse_int_env("NITTER_MAX_ITEM_AGE_SECONDS", 2 * 60 * 60, min_value=0)
 
 DEFAULT_INTERVAL = 15 * 60  # Sekunden
 USER_OVERRIDES = {
@@ -81,6 +101,8 @@ logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s %(levelname)s %(message)s",
 )
+for _warning in _ENV_PARSE_WARNINGS:
+    logging.warning(_warning)
 
 def parse_time(value: str | None) -> dtime | None:
     if not value:


### PR DESCRIPTION
## Summary
- add robust numeric ENV parser in `nitter_bot.py` with fallback defaults and warning logging
- add robust numeric ENV parser in `mastodon_control_bot.py` for poll interval and event port
- prevent startup crashes from invalid numeric ENV values by clamping to safe bounds/defaults

## Checks
- `python3 -m compileall .` (fails in vendored `venv` site-packages with legacy asyncio syntax)
- `python3 -m compileall -q -x '(^|/)venv($|/)' .`
- `env NITTER_POLL_INTERVAL=abc ./venv/bin/python nitter_bot.py --help` (exit 0)
- `env MASTODON_CONTROL_EVENT_PORT=abc timeout 6 ./venv/bin/python mastodon_control_bot.py` (no ValueError crash; process stays running until timeout)

Fixes #10
