### PR TITLE
Use network-online.target in bot service units

### DIFF
--- a/services/bsky_bot.service
+++ b/services/bsky_bot.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=bsky_bot
-After=network.target
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 EnvironmentFile=/etc/twitter_bot.env

--- a/services/mastodon_control_bot.service
+++ b/services/mastodon_control_bot.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=mastodon_control_bot
-After=network.target
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 EnvironmentFile=/etc/twitter_bot.env

--- a/services/nitter_bot.service
+++ b/services/nitter_bot.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=nitter_bot
-After=network.target
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 EnvironmentFile=/etc/twitter_bot.env

--- a/services/telegram_control_bot.service
+++ b/services/telegram_control_bot.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=telegram_control_bot
-After=network.target
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 EnvironmentFile=/etc/twitter_bot.env

--- a/services/twitter_bot.service
+++ b/services/twitter_bot.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=twitter_bot
-After=network.target
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 EnvironmentFile=/etc/twitter_bot.env


### PR DESCRIPTION
## Summary
- add `Wants=network-online.target` and `After=network-online.target` to all bot systemd units
- keep existing runtime and restart settings unchanged

## Checks
- `python3 -m compileall .` (fails in vendored `venv` site-packages with legacy asyncio syntax)
- `python3 -m compileall -q -x '(^|/)venv($|/)' .`
- `systemd-analyze verify services/*.service`

Fixes #11
