### PR TITLE
Make BOTS_BASE_DIR resolution resilient to invalid paths

### DIFF
--- a/paths.py
+++ b/paths.py
@@ -4,7 +4,21 @@ import os
 from pathlib import Path
 
 
-BASE_DIR = Path(os.environ.get("BOTS_BASE_DIR") or Path(__file__).resolve().parent).resolve()
+def _resolve_base_dir() -> Path:
+    default_dir = Path(__file__).resolve().parent
+    requested_raw = os.environ.get("BOTS_BASE_DIR")
+    requested = Path(requested_raw).expanduser() if requested_raw else default_dir
+    resolved = requested.resolve()
+    try:
+        resolved.mkdir(parents=True, exist_ok=True)
+        return resolved
+    except OSError:
+        # Fallback keeps startup alive when BOTS_BASE_DIR is invalid/unwritable.
+        default_dir.mkdir(parents=True, exist_ok=True)
+        return default_dir
+
+
+BASE_DIR = _resolve_base_dir()
 LOG_FILE = str(BASE_DIR / "twitter_bot.log")
 LOG_DIR = str(BASE_DIR / "logs")
 DATA_FILE = str(BASE_DIR / "data.json")


### PR DESCRIPTION
## Summary
- harden `BOTS_BASE_DIR` resolution in `paths.py`
- auto-create requested base directory when possible
- fall back to repository directory when requested path is invalid/unwritable
- preserve existing `paths.py` public constants (`LOG_FILE`, `DEFAULT_DB_PATH`, ...)

## Checks
- ./venv/bin/python -m compileall -q -x '(^|/)venv($|/)' .
- ./venv/bin/python -m pytest -q tests
- ./venv/bin/python -m ruff check paths.py

Fixes #20
