### PR TITLE
Fix startup crash for invalid BOTS_BASE_DIR

### DIFF
--- a/nitter_bot.py
+++ b/nitter_bot.py
@@ -21,10 +21,7 @@ import telegram_bot
 import mastodon_bot
 import state_store
 from url_safety import validate_outbound_url
-from paths import BASE_DIR as DEFAULT_BASE_DIR
-
-BASE_DIR = os.environ.get("BOTS_BASE_DIR", str(DEFAULT_BASE_DIR))
-LOG_PATH = os.path.join(BASE_DIR, "twitter_bot.log")
+from paths import LOG_FILE
 _ENV_PARSE_WARNINGS: list[str] = []
 
 
@@ -100,7 +97,7 @@ TEXT_URL_RX = re.compile(
 MENTION_RE = re.compile(r"(?<!\w)@([A-Za-z0-9_]{1,30})")
 
 logging.basicConfig(
-    handlers=[WatchedFileHandler(LOG_PATH)],
+    handlers=[WatchedFileHandler(LOG_FILE)],
     level=logging.INFO,
     format="%(asctime)s %(levelname)s %(message)s",
 )

--- a/paths.py
+++ b/paths.py
@@ -4,18 +4,41 @@ import os
 from pathlib import Path
 
 
+def _ensure_writable_dir(path: Path) -> bool:
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        return False
+
+    probe_file = path / ".bots_write_probe"
+    try:
+        probe_file.touch(exist_ok=True)
+    except OSError:
+        return False
+    finally:
+        try:
+            probe_file.unlink()
+        except OSError:
+            pass
+    return True
+
+
 def _resolve_base_dir() -> Path:
     default_dir = Path(__file__).resolve().parent
     requested_raw = os.environ.get("BOTS_BASE_DIR")
     requested = Path(requested_raw).expanduser() if requested_raw else default_dir
-    resolved = requested.resolve()
     try:
-        resolved.mkdir(parents=True, exist_ok=True)
-        return resolved
+        resolved = requested.resolve()
     except OSError:
-        # Fallback keeps startup alive when BOTS_BASE_DIR is invalid/unwritable.
-        default_dir.mkdir(parents=True, exist_ok=True)
+        resolved = default_dir
+
+    if _ensure_writable_dir(resolved):
+        return resolved
+
+    if _ensure_writable_dir(default_dir):
         return default_dir
+
+    return Path.cwd()
 
 
 BASE_DIR = _resolve_base_dir()


### PR DESCRIPTION
## Summary
Fixes startup crash when `BOTS_BASE_DIR` points to a non-writable directory by hardening base-dir resolution and making `nitter_bot` consume the shared resilient log path.

## Checks
- `./venv/bin/python -m compileall -q -x '(^|/)venv($|/)' .`
- `./venv/bin/pytest -q tests tests-unit`
- `./venv/bin/ruff check .`

## Modules touched
- `paths.py`
- `nitter_bot.py`

Fixes #44
