### PR TITLE
Harden log rotation permissions and ignore archives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 __pycache__/
 *.py[cod]
 *.log
+*.log.*
 .pytest_cache/
 .mypy_cache/
 venv/
@@ -8,3 +9,4 @@ venc/
 .env
 .DS_Store
 data.json
+logs/

--- a/rotate_twitter_log.sh
+++ b/rotate_twitter_log.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -euo pipefail
+umask 077
 
 BASE_DIR="${BOTS_BASE_DIR:-$(cd "$(dirname "$0")" && pwd)}"
 LOGFILE="${BOT_LOG_FILE:-$BASE_DIR/twitter_bot.log}"
@@ -21,8 +22,9 @@ mkdir -p "$(dirname "$LOGFILE")"
 
 if [ -f "$LOGFILE" ]; then
     mv "$LOGFILE" "$ARCHIVED_LOG"
+    chmod 600 "$ARCHIVED_LOG"
 fi
 
-install -m 644 /dev/null "$LOGFILE"
+install -m 600 /dev/null "$LOGFILE"
 
 find "$LOGDIR" -type f -name "twitter_bot.log.*" -mtime +14 -delete


### PR DESCRIPTION
## Summary
Harden log handling by tightening rotation file permissions and preventing archived log files from being accidentally committed.

## Checks
- `./venv/bin/python -m compileall -q -x '(^|/)venv($|/)' .`
- `./venv/bin/pytest -q tests tests-unit`
- `./venv/bin/ruff check .`
- `BOTS_BASE_DIR=$(mktemp -d) PYTHON_BIN=/bin/true bash rotate_twitter_log.sh` + `stat`

## Modules touched
- `.gitignore`
- `rotate_twitter_log.sh`

Fixes #46
